### PR TITLE
Opsera Hummingbird AI: Converted Bamboo plan TEST-TEST to GHA

### DIFF
--- a/.github/workflows/TEST-TEST.yml
+++ b/.github/workflows/TEST-TEST.yml
@@ -1,0 +1,20 @@
+name: Test Pipeline
+on:
+  schedule:
+    - cron: '*/3 * * * *'
+  push:
+  pull_request:
+jobs:
+  spring:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+  default_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+permissions:
+  contents: read
+  pull-requests: write


### PR DESCRIPTION


pipeline migrated from Bamboo plan [TEST-TEST](https://bamboo.shared-private.opsera.io//browse/TEST-TEST) to GitHub Actions using Opsera Hummingbird AI
---

### Action Items:
- [ ] Identify and implement tasks or plugins used in Bamboo that do not have direct equivalents in GitHub Actions.
- [ ] Configure repository secrets for any sensitive data or credentials used in the workflow.
- [ ] Review the schedule trigger's cron expression to ensure it matches the original Bamboo configuration's intent.
- [ ] Manually set up branch creation and deletion rules in the GitHub repository settings, as these cannot be directly controlled through GitHub Actions workflows.
- [ ] Assign GitHub Actions permissions as necessary, based on the Bamboo plan permissions. Manual intervention required to map users and roles to GitHub equivalents.
- [ ] There's no direct equivalent for Bamboo's artifact subscriptions in GitHub Actions. Consider using artifacts uploading and downloading steps or external storage solutions.
- [ ] The concurrency and build expiry configurations in Bamboo do not have direct GitHub Actions equivalents. For concurrency, explore using `concurrency` at the job or workflow level in GitHub Actions. Build expiry needs to be managed through repository or external tools.
